### PR TITLE
PREFER using lowerCamelCase for constant names

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Title: Flutter Interview Questions
 * What are keys in Flutter and when should you use it?
 * What are `GlobalKeys`?
 * When should you use `mainAxisAlignment` and `crossAxisAlignment`?
-* When can you use `double.INFINITY`?
+* When can you use `double.infinityINFINITY`?
 * What is `Ticker`, `Tween` and `AnimatedBuilder`?
 * What is ephemeral state?
 * What is an `AspectRatio` widget used for?


### PR DESCRIPTION
* [Effective Dart: Style](https://dart.dev/guides/language/effective-dart/style#prefer-using-lowercamelcase-for-constant-names)
* [Linter rule](https://dart-lang.github.io/linter/lints/constant_identifier_names.html)

PREFER using lowerCamelCase for constant names.

In new code, use lowerCamelCase for constant variables, including enum values.

In existing code that uses ALL_CAPS_WITH_UNDERSCORES for constants, you may continue to use all caps to stay consistent.